### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -24,6 +26,8 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Potential fix for [https://github.com/bQuery/bQuery/security/code-scanning/2](https://github.com/bQuery/bQuery/security/code-scanning/2)

In general, the fix is to add explicit `permissions` blocks to jobs (or at the workflow root) so that `GITHUB_TOKEN` has only the minimal rights required. For simple build/test jobs that only need to fetch source via `actions/checkout`, `contents: read` is sufficient. Jobs that publish packages or deploy pages can retain their more permissive, already‑declared permissions.

For this workflow, we should add `permissions: contents: read` to the `build` and `build-docs` jobs. This keeps existing functionality unchanged: `actions/checkout@v4` works with `contents: read`, and the rest of the steps only run local commands (`bun install`, `bun test`, `bun run build`, `bun run build:docs`, `actions/upload-pages-artifact@v3`) that do not require extra GitHub permissions. The `publish-npm` and `deploy-pages` jobs already have appropriate explicit permissions and should be left as is.

Concretely:
- In `.github/workflows/npm-publish.yml`, under `jobs.build`, insert:
  ```yaml
  permissions:
    contents: read
  ```
  at the same indentation level as `runs-on`.
- Under `jobs.build-docs`, also insert:
  ```yaml
  permissions:
    contents: read
  ```
  at the same level as `runs-on`.

No additional imports, methods, or external definitions are required, since this is purely a workflow‑YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
