### PR TITLE
Version 1.1.1

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -24,6 +26,8 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to Semantic Versioning.
 
+## [1.1.1] - 2026-01-24
+
+### Fixed
+
+- Fixed a possibly dangrous html handling in the playground examples.
+
 ## [1.1.0] - 2026-01-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bquery/bquery",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The jQuery for the Modern Web Platform - Zero build, TypeScript-first library with reactivity, components, and motion",
   "type": "module",
   "main": "./dist/full.umd.js",

--- a/playground/src/demos/core.ts
+++ b/playground/src/demos/core.ts
@@ -493,7 +493,12 @@ component('demo-events', {
       const logEvent = (type: string, detail: string) => {
         const item = document.createElement('div');
         item.className = 'log-item';
-        item.innerHTML = `<span class="event-type">${type}</span> ${detail}`;
+        const typeBadge = document.createElement('span');
+        typeBadge.className = 'event-type';
+        typeBadge.textContent = type;
+
+        item.appendChild(typeBadge);
+        item.appendChild(document.createTextNode(` ${detail}`));
         $log.prepend(item);
 
         // Keep only last 5 entries
@@ -605,7 +610,7 @@ component('demo-collection', {
         // Re-append in shuffled order and clear classes
         $$(items)
           .removeClass('selected', 'even')
-          .each((el: Element) => grid.appendChild(el));
+          .each((el) => grid.appendChild(el.raw));
       });
 
       // Reset - demonstrates removeClass() on collection


### PR DESCRIPTION
This pull request addresses a security fix and makes minor improvements to the workflow configuration and documentation. The main change resolves a potentially dangerous HTML handling issue in the playground examples, and there are small updates to the GitHub Actions workflow and versioning.

Security and Playground Fixes:
* Replaced direct assignment of HTML via `innerHTML` with safer DOM manipulation in the `logEvent` function within `playground/src/demos/core.ts` to prevent possible HTML injection vulnerabilities.
* Updated collection handling in the same file to use the raw DOM element when re-appending items, improving code clarity and safety.

Workflow and Versioning:
* Added explicit `contents: read` permissions to both `build` and `build-docs` jobs in `.github/workflows/npm-publish.yml` to comply with GitHub Actions best practices. [[1]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240R16-R17) [[2]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240R29-R30)
* Bumped package version to `1.1.1` in `package.json` to reflect the new release.
* Added a changelog entry for version `1.1.1` noting the HTML handling fix in `CHANGELOG.md`.