### PR TITLE
Version 1.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ temp/
 .cache/
 .npm/
 */.vitepress/cache/
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to Semantic Versioning.
 
+## [1.1.2] - 2026-01-24
+
+### Fixed
+
+- **Docs**: Fixed import paths and added error handling in agents documentation.
+
+### Security
+
+- Added `rel="noopener noreferrer"` to external links for improved security.
+
 ## [1.1.1] - 2026-01-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ const safe = sanitize('<form id="cookie">...</form>'); // id stripped
 // Unicode bypass protection in URLs
 const urlSafe = sanitize('<a href="java\u200Bscript:alert(1)">click</a>');
 
+// Automatic link security (adds rel="noopener noreferrer" to external/target="_blank" links)
+const secureLink = sanitize('<a href="https://external.com" target="_blank">Link</a>');
+
 // Escape for text display
 const escaped = escapeHtml('<script>alert(1)</script>');
 ```

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -55,6 +55,35 @@ sanitize('<a href="java\u200Bscript:alert(1)">click</a>');
 // Result: <a>click</a>
 ```
 
+### Automatic Link Security
+
+bQuery automatically adds `rel="noopener noreferrer"` to links that:
+
+1. Have `target="_blank"` attribute (open in new window/tab)
+2. Point to external domains (different origin)
+
+This protects against:
+- **Tabnabbing attacks**: prevents the opened page from accessing `window.opener`
+- **Referrer leakage**: prevents sensitive information in the URL from being sent
+
+```ts
+// Links with target="_blank" get security attributes
+sanitize('<a href="/page" target="_blank">Link</a>');
+// Result: <a href="/page" target="_blank" rel="noopener noreferrer">Link</a>
+
+// External links get security attributes automatically
+sanitize('<a href="https://external.com">Link</a>');
+// Result: <a href="https://external.com" rel="noopener noreferrer">Link</a>
+
+// Existing rel values are preserved
+sanitize('<a href="https://external.com" rel="author">Link</a>');
+// Result: <a href="https://external.com" rel="author noopener noreferrer">Link</a>
+
+// Internal links without target="_blank" are unchanged
+sanitize('<a href="/internal">Link</a>');
+// Result: <a href="/internal">Link</a>
+```
+
 ### Options
 
 - `allowTags?: string[]`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bquery/bquery",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The jQuery for the Modern Web Platform - Zero build, TypeScript-first library with reactivity, components, and motion",
   "type": "module",
   "main": "./dist/full.umd.js",

--- a/src/security/sanitize.ts
+++ b/src/security/sanitize.ts
@@ -261,11 +261,13 @@ const DEFAULT_ALLOWED_ATTRIBUTES = new Set([
   'lang',
   'loading',
   'name',
+  'rel',
   'role',
   'src',
   'srcset',
   'style',
   'tabindex',
+  'target',
   'title',
   'type',
   'width',
@@ -352,6 +354,50 @@ const isSafeUrl = (value: string): boolean => {
 };
 
 /**
+ * Check if a URL is external (different origin).
+ * @internal
+ */
+const isExternalUrl = (url: string): boolean => {
+  try {
+    // Normalize URL by trimming whitespace
+    const trimmedUrl = url.trim();
+    
+    // Protocol-relative URLs (//example.com) are always external
+    if (trimmedUrl.startsWith('//')) {
+      return true;
+    }
+    
+    // Normalize URL for case-insensitive protocol checks
+    const lowerUrl = trimmedUrl.toLowerCase();
+    
+    // Check for non-http(s) protocols which are considered external/special
+    // (mailto:, tel:, ftp:, etc.)
+    const hasProtocol = /^[a-z][a-z0-9+.-]*:/i.test(trimmedUrl);
+    if (hasProtocol && !lowerUrl.startsWith('http://') && !lowerUrl.startsWith('https://')) {
+      // These are special protocols, not traditional "external" links
+      // but we treat them as external for security consistency
+      return true;
+    }
+    
+    // Relative URLs are not external
+    if (!lowerUrl.startsWith('http://') && !lowerUrl.startsWith('https://')) {
+      return false;
+    }
+    
+    // In non-browser environments (e.g., Node.js), treat all absolute URLs as external
+    if (typeof window === 'undefined' || !window.location) {
+      return true;
+    }
+    
+    const urlObj = new URL(trimmedUrl, window.location.href);
+    return urlObj.origin !== window.location.origin;
+  } catch {
+    // If URL parsing fails, treat as potentially external for safety
+    return true;
+  }
+};
+
+/**
  * Core sanitization logic (without Trusted Types wrapper).
  * @internal
  */
@@ -432,6 +478,28 @@ const sanitizeHtmlCore = (html: string, options: SanitizeOptions = {}): string =
     // Remove disallowed attributes
     for (const attrName of attrsToRemove) {
       el.removeAttribute(attrName);
+    }
+
+    // Add rel="noopener noreferrer" to external links for security
+    if (tagName === 'a') {
+      const href = el.getAttribute('href');
+      const target = el.getAttribute('target');
+      const hasTargetBlank = target?.toLowerCase() === '_blank';
+      const isExternal = href && isExternalUrl(href);
+
+      // Add security attributes to links opening in new window or external links
+      if (hasTargetBlank || isExternal) {
+        const existingRel = el.getAttribute('rel');
+        const relValues = new Set(
+          existingRel ? existingRel.split(/\s+/).filter(Boolean) : []
+        );
+        
+        // Add noopener and noreferrer
+        relValues.add('noopener');
+        relValues.add('noreferrer');
+        
+        el.setAttribute('rel', Array.from(relValues).join(' '));
+      }
     }
   }
 

--- a/src/security/sanitize.ts
+++ b/src/security/sanitize.ts
@@ -362,7 +362,11 @@ const isExternalUrl = (url: string): boolean => {
     // Normalize URL by trimming whitespace
     const trimmedUrl = url.trim();
     
-    // Protocol-relative URLs (//example.com) are always external
+    // Protocol-relative URLs (//example.com) are always external.
+    // CRITICAL: This check must run before the relative-URL check below;
+    // otherwise, a protocol-relative URL like "//evil.com" would be treated
+    // as a non-http(s) relative URL and incorrectly classified as same-origin.
+    // Handling them up front guarantees correct security classification.
     if (trimmedUrl.startsWith('//')) {
       return true;
     }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -131,7 +131,7 @@ describe('utils/math helpers', () => {
   });
 
   it('randomInt returns value in range', () => {
-    for (let i = 0; i < 100; i++) {
+    for (let attempt = 0; attempt < 20; attempt++) {
       const result = utils.randomInt(1, 6);
       expect(result).toBeGreaterThanOrEqual(1);
       expect(result).toBeLessThanOrEqual(6);
@@ -192,6 +192,9 @@ describe('utils/security', () => {
   it('merge ignores prototype pollution keys', () => {
     const malicious = JSON.parse('{"__proto__": {"polluted": true}}');
     const result = utils.merge({}, malicious);
+
+    // The result itself should not contain the polluted property
+    expect((result as Record<string, unknown>).polluted).toBeUndefined();
 
     // Should not pollute Object prototype
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();


### PR DESCRIPTION
This pull request focuses on improving link security in the HTML sanitizer by automatically adding `rel="noopener noreferrer"` to external and `target="_blank"` links, updating documentation and tests accordingly, and making minor documentation and test improvements. These changes help prevent tabnabbing and referrer leakage vulnerabilities while ensuring the sanitizer's behavior is well-documented and robustly tested.

**Security enhancements:**

* Added logic in `sanitize.ts` to automatically add `rel="noopener noreferrer"` to `<a>` tags that either have `target="_blank"` or point to external domains, including protocol-relative URLs and special protocols like `mailto:` and `tel:`. Existing `rel` values are preserved and merged. [[1]](diffhunk://#diff-661a9f5ca84cb3668a2ebf96d24a7724d789597aad92ad19dc2ac9019b36e848R482-R503) [[2]](diffhunk://#diff-661a9f5ca84cb3668a2ebf96d24a7724d789597aad92ad19dc2ac9019b36e848R356-R399)
* Updated the set of allowed attributes in the sanitizer to include `rel` and `target`.

**Documentation updates:**

* Updated `CHANGELOG.md` to document the security improvements and documentation fixes.
* Expanded the security guide (`docs/guide/security.md`) with a new section on automatic link security, including code examples for various link scenarios.
* Updated usage examples in `README.md` to demonstrate the new link security behavior.
* Fixed import paths and improved error handling in the agents guide, and clarified backend call error handling. [[1]](diffhunk://#diff-26313617f907237bd6d0bcea48cfd9ff8ff54c51f38731fc693e5ceaa8a93fe1L56-R57) [[2]](diffhunk://#diff-26313617f907237bd6d0bcea48cfd9ff8ff54c51f38731fc693e5ceaa8a93fe1R66-R108) [[3]](diffhunk://#diff-26313617f907237bd6d0bcea48cfd9ff8ff54c51f38731fc693e5ceaa8a93fe1L112-R139)

**Testing improvements:**

* Added comprehensive tests to `security.test.ts` to cover the new link security behavior, including edge cases for various protocols, casing, whitespace, SSR/Node.js environments, and preservation of existing `rel` values.
* Minor improvements to utility tests for reliability and coverage. [[1]](diffhunk://#diff-c37842b08434952211c06ad3cdc71258303dcce7491a2b5f2005876cfbc26681L134-R134) [[2]](diffhunk://#diff-c37842b08434952211c06ad3cdc71258303dcce7491a2b5f2005876cfbc26681R196-R198)

**Version bump:**

* Bumped package version to `1.1.2` in `package.json` to reflect the new release.