### PR TITLE
Version 1.8.1 FIX

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,86 +1,114 @@
 core:
-  - 'src/core/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/core/**'
 
 reactive:
-  - 'src/reactive/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/reactive/**'
 
 component:
-  - 'src/component/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/component/**'
 
 motion:
-  - 'src/motion/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/motion/**'
 
 platform:
-  - 'src/platform/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/platform/**'
 
 router:
-  - 'src/router/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/router/**'
 
 security:
-  - 'src/security/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/security/**'
 
 store:
-  - 'src/store/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/store/**'
 
 view:
-  - 'src/view/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/view/**'
 
 forms:
-  - 'src/forms/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/forms/**'
 
 i18n:
-  - 'src/i18n/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/i18n/**'
 
 a11y:
-  - 'src/a11y/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/a11y/**'
 
 dnd:
-  - 'src/dnd/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/dnd/**'
 
 media:
-  - 'src/media/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/media/**'
 
 plugin:
-  - 'src/plugin/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/plugin/**'
 
 devtools:
-  - 'src/devtools/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/devtools/**'
 
 testing:
-  - 'src/testing/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/testing/**'
 
 ssr:
-  - 'src/ssr/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/ssr/**'
 
 storybook:
-  - 'src/storybook/**'
+  - changed-files:
+      - any-glob-to-any-file: 'src/storybook/**'
 
 docs:
-  - 'docs/**'
-  - '*.md'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '*.md'
 
 tests:
-  - 'tests/**'
-  - '**/*.test.ts'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tests/**'
+          - '**/*.test.ts'
 
 build:
-  - 'package.json'
-  - 'bun.lock'
-  - 'bunfig.toml'
-  - 'vite*.ts'
-  - 'tsconfig*.json'
-  - 'eslint.config.js'
-  - 'typedoc.json'
-  - '.prettier*'
-  - '.npmignore'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'bun.lock'
+          - 'bunfig.toml'
+          - 'vite*.ts'
+          - 'tsconfig*.json'
+          - 'eslint.config.js'
+          - 'typedoc.json'
+          - '.prettier*'
+          - '.npmignore'
 
 ci/cd:
-  - '.github/workflows/**'
+  - changed-files:
+      - any-glob-to-any-file: '.github/workflows/**'
 
 github:
-  - '.github/ISSUE_TEMPLATE/**'
-  - '.github/FUNDING.yml'
-  - '.github/copilot-instructions.md'
-  - '.clinerules'
-  - '.cursorrules'
-  - 'llms.txt'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/ISSUE_TEMPLATE/**'
+          - '.github/FUNDING.yml'
+          - '.github/copilot-instructions.md'
+          - '.clinerules'
+          - '.cursorrules'
+          - 'llms.txt'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           dot: true
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,4 +19,3 @@ jobs:
       - uses: actions/labeler@v6
         with:
           dot: true
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to Semantic Versioning.
 
 - [Changelog](#changelog)
   - [Releases](#releases)
+  - [\[1.8.1\] - 2026-04-01](#181---2026-04-01)
+    - [Fixed (1.8.1)](#fixed-181)
   - [\[1.8.0\] - 2026-04-01](#180---2026-04-01)
     - [Added (1.8.0)](#added-180)
     - [Changed (1.8.0)](#changed-180)
@@ -52,6 +54,12 @@ and this project adheres to Semantic Versioning.
     - [Fixed (1.0.1)](#fixed-101)
   - [\[1.0.0\] - 2026-01-21](#100---2026-01-21)
     - [Added (1.0.0)](#added-100)
+
+## [1.8.1] - 2026-04-01
+
+### Fixed (1.8.1)
+
+- **Plugin / View**: Custom directives registered through `@bquery/bquery/plugin` now reattach their view-side resolver when plugins are installed or reset, so plugin-provided `bq-*` directives continue to run reliably after resolver teardown in isolated test runs and other reinitialized environments.
 
 ## [1.8.0] - 2026-04-01
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,8 @@
       "devDependencies": {
         "@storybook/addon-docs": "^10.3.3",
         "@storybook/web-components-vite": "^10.3.3",
-        "@typescript-eslint/eslint-plugin": "^8.57.2",
-        "@typescript-eslint/parser": "^8.57.2",
+        "@typescript-eslint/eslint-plugin": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.0",
         "bun-types": "^1.3.11",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bquery/bquery",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "The jQuery for the Modern Web Platform - Zero build, TypeScript-first library with reactivity, components, and motion",
   "type": "module",
   "main": "./dist/full.umd.js",

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -31,7 +31,19 @@ type PendingComponentRegistration = {
   options?: ElementDefinitionOptions;
 };
 
-registerCustomDirectiveResolver((name) => customDirectives.get(name));
+/**
+ * Ensure the view pipeline resolves plugin directives against the current registry.
+ *
+ * This is intentionally idempotent so tests or internal modules can temporarily
+ * clear the resolver without leaving plugin/view integration in a broken state.
+ *
+ * @internal
+ */
+const attachCustomDirectiveResolver = (): void => {
+  registerCustomDirectiveResolver((name) => customDirectives.get(name));
+};
+
+attachCustomDirectiveResolver();
 
 /**
  * Restore the directive registry to a previously captured snapshot.
@@ -147,6 +159,8 @@ export const use = <TOptions = unknown>(
   plugin: BQueryPlugin<TOptions>,
   options?: TOptions
 ): void => {
+  attachCustomDirectiveResolver();
+
   if (!plugin || typeof plugin !== 'object') {
     throw new Error('bQuery plugin: use() expects a plugin object with { name, install }');
   }
@@ -266,4 +280,5 @@ export const getCustomDirectives = (): readonly CustomDirective[] =>
 export const resetPlugins = (): void => {
   installedPlugins.clear();
   customDirectives.clear();
+  attachCustomDirectiveResolver();
 };

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -12,6 +12,7 @@ import {
   resetPlugins,
   use,
 } from '../src/plugin/index';
+import { registerCustomDirectiveResolver } from '../src/view/custom-directives';
 import {
   createForHandler,
   handleBind,
@@ -528,6 +529,28 @@ describe('Plugin System', () => {
   // ==========================================================================
 
   describe('view integration', () => {
+    it('should reattach the custom directive resolver when it was cleared before plugin use', () => {
+      const calls: string[] = [];
+
+      registerCustomDirectiveResolver(null);
+
+      use({
+        name: 'resolver-reattach-plugin',
+        install(ctx) {
+          ctx.directive('reattach', (_el, expression) => {
+            calls.push(expression);
+          });
+        },
+      });
+
+      const el = document.createElement('div');
+      el.setAttribute('bq-reattach', 'works');
+
+      processElement(el, {}, 'bq', [], createDirectiveHandlers());
+
+      expect(calls).toEqual(['works']);
+    });
+
     it('should invoke custom directive handler when processing DOM elements', () => {
       const calls: Array<{ el: Element; expr: string }> = [];
 


### PR DESCRIPTION
This pull request releases version `1.8.1` of `@bquery/bquery`, focusing on improving the reliability of plugin-provided custom directives, especially in test environments or when the view resolver is reset. The main fix ensures that custom directive resolvers are always reattached after plugins are installed or reset, preventing issues where `bq-*` directives would stop working after resolver teardown. The update also includes a new test to verify this behavior.

**Changelog and Versioning:**

* Updated `CHANGELOG.md` with a new section for version `1.8.1`, documenting the fix for plugin/view integration. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R12) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR58-R63)
* Bumped the package version in `package.json` from `1.8.0` to `1.8.1`.

**Plugin/View Integration Reliability:**

* Added `attachCustomDirectiveResolver()` in `src/plugin/registry.ts` to ensure the view pipeline always resolves plugin directives, and invoked it during initialization, plugin installation, and plugin reset. [[1]](diffhunk://#diff-9e45a00cd2f01cec1b8a8b0fd31394db4b334bb73380c71ccdb111723fbda11dR34-R46) [[2]](diffhunk://#diff-9e45a00cd2f01cec1b8a8b0fd31394db4b334bb73380c71ccdb111723fbda11dR162-R163) [[3]](diffhunk://#diff-9e45a00cd2f01cec1b8a8b0fd31394db4b334bb73380c71ccdb111723fbda11dR283)

**Testing:**

* Added a test in `tests/plugin.test.ts` to confirm that the custom directive resolver is correctly reattached if cleared before plugin installation. [[1]](diffhunk://#diff-377b64b5673fd4dd606c99e6592852a4f7c7344fc26dcffc1849936130ddc8aaR15) [[2]](diffhunk://#diff-377b64b5673fd4dd606c99e6592852a4f7c7344fc26dcffc1849936130ddc8aaR532-R553)