### PR TITLE
Add Google site verification meta tag to config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   base: process.env.VITEPRESS_BASE ?? '/',
   head: [
     ['link', { rel: 'icon', href: '/assets/bquerry-logo.svg' }],
-    ['meta', { property: 'google-site-verification', content: 'injOs87iZEPOqUJhHQiKuXhzvuD7XL4dyXxyDpx4Sx8' }],
+    ['meta', { name: 'google-site-verification', content: 'injOs87iZEPOqUJhHQiKuXhzvuD7XL4dyXxyDpx4Sx8' }],
   ],
   lastUpdated: true,
   vite: {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   base: process.env.VITEPRESS_BASE ?? '/',
   head: [
     ['link', { rel: 'icon', href: '/assets/bquerry-logo.svg' }],
+    ['meta', { property: 'google-site-verification', content: 'injOs87iZEPOqUJhHQiKuXhzvuD7XL4dyXxyDpx4Sx8' }],
   ],
   lastUpdated: true,
   vite: {


### PR DESCRIPTION
This pull request makes a minor update to the VitePress documentation site configuration by adding a Google site verification meta tag to the HTML head. This helps verify site ownership for Google Search Console.

* Added a `google-site-verification` meta tag to the `head` array in `docs/.vitepress/config.ts`.