### PR TITLE
Add sitemap configuration to VitePress

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     ['meta', { name: 'google-site-verification', content: 'injOs87iZEPOqUJhHQiKuXhzvuD7XL4dyXxyDpx4Sx8' }],
   ],
   sitemap: {
-    hostname: 'https://bquery.js.org'
+    hostname: 'https://bquery.js.org',
   },
   lastUpdated: true,
   vite: {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     ['link', { rel: 'icon', href: '/assets/bquerry-logo.svg' }],
     ['meta', { name: 'google-site-verification', content: 'injOs87iZEPOqUJhHQiKuXhzvuD7XL4dyXxyDpx4Sx8' }],
   ],
+  sitemap: {
+    hostname: 'https://bquery.js.org'
+  },
   lastUpdated: true,
   vite: {
     build: {


### PR DESCRIPTION
This pull request adds a sitemap configuration to the VitePress documentation site, specifying the website's hostname for sitemap generation.

- Documentation configuration:
  * Added a `sitemap` property with the `hostname` set to `'https://bquery.js.org'` in `docs/.vitepress/config.ts` to enable sitemap generation for the site.