### PR TITLE
Fix for Invalid prototype value

### DIFF
--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -2639,11 +2639,22 @@ describe('Router', () => {
 
     it('should preserve existing history state when adding scroll restoration state', async () => {
       const originalStateDescriptor = Object.getOwnPropertyDescriptor(history, 'state');
-      mockHistory.getStack()[0]!.state = Object.assign(Object.create(null), {
+      const initialState = Object.assign(Object.create(null), {
         preserved: 'value',
-        constructor: 'ignored',
-        __proto__: 'ignored',
+      }) as Record<string, unknown>;
+      Object.defineProperty(initialState, 'constructor', {
+        value: 'ignored',
+        enumerable: true,
+        configurable: true,
+        writable: true,
       });
+      Object.defineProperty(initialState, '__proto__', {
+        value: 'ignored',
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      mockHistory.getStack()[0]!.state = initialState;
 
       Object.defineProperty(history, 'state', {
         configurable: true,


### PR DESCRIPTION
To fix this without changing test behavior, avoid using `__proto__` directly in an object literal.  
Best approach: build the null-prototype state object first, then define suspicious keys (`constructor`, `__proto__`) as plain own data properties via `Object.defineProperty`.

In `tests/router.test.ts` around lines 2642–2646:
- Replace the current `Object.assign(Object.create(null), { ... __proto__: 'ignored' ... })` construction.
- Create a local `initialState` object from `Object.create(null)`.
- Set `preserved` normally.
- Add `constructor` and `__proto__` using `Object.defineProperty(..., { value: 'ignored', enumerable: true, configurable: true, writable: true })`.
- Assign `initialState` back to `mockHistory.getStack()[0]!.state`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._