### PR TITLE
Fix for Invalid prototype value

### DIFF
--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -332,10 +332,10 @@ describe('View', () => {
 
     it('should ignore prototype-pollution keys in expression-returned ARIA maps', () => {
       container.innerHTML = '<div bq-aria="ariaState"></div>';
-      const initialState = Object.create(null) as Record<string, string>;
+      const initialState = Object.create(null) as Record<string, unknown>;
       initialState.label = 'Safe label';
       Object.defineProperty(initialState, '__proto__', {
-        value: 'unsafe',
+        value: { polluted: true },
         enumerable: true,
         configurable: true,
       });
@@ -346,7 +346,7 @@ describe('View', () => {
       const div = container.querySelector('div')!;
       expect(div.getAttribute('aria-label')).toBe('Safe label');
       expect(div.hasAttribute('aria-__proto__')).toBe(false);
-      expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'unsafe')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'polluted')).toBe(false);
     });
 
     it('should accept keys that already include the aria- prefix', () => {


### PR DESCRIPTION
The safest fix is to keep testing that `__proto__` keys are ignored, but avoid assigning a string to `__proto__`.  
In `tests/view.test.ts`, inside the test `should ignore prototype-pollution keys in expression-returned ARIA maps`, change the `Object.defineProperty` value from `'unsafe'` to an object (or `null`). This preserves functionality: the key remains present and enumerable for the directive logic to filter out, while removing the invalid-prototype-type pattern flagged by CodeQL.

Concretely:
- Edit only the block around lines 337–341.
- Replace `value: 'unsafe'` with `value: { polluted: true }` (or `null`).
- Update the final assertion on line 349 so it still verifies no pollution (`'polluted'` should not exist on `Object.prototype`).

No imports, helper methods, or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._