### PR TITLE
Fix for Invalid prototype value

### DIFF
--- a/tests/ssr.test.ts
+++ b/tests/ssr.test.ts
@@ -502,12 +502,16 @@ describe('serializeStoreState', () => {
   });
 
   it('sanitizes dangerous top-level store state keys during serialization', () => {
-    const pollutedState = Object.assign(Object.create(null), {
-      safe: 'ok',
-      constructor: 'bad',
-      prototype: 'bad',
-      ['__proto__']: 'bad',
-    }) as Record<string, unknown>;
+    const pollutedState = Object.create(null) as Record<string, unknown>;
+    pollutedState.safe = 'ok';
+    pollutedState.constructor = 'bad';
+    pollutedState.prototype = 'bad';
+    Object.defineProperty(pollutedState, '__proto__', {
+      value: 'bad',
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
 
     createStore({ id: 'serialize-pollution', state: () => pollutedState });
 


### PR DESCRIPTION
To fix this safely without changing functionality, avoid creating `__proto__` via object-literal assignment in `Object.assign`. Instead, build the null-prototype object and define `__proto__` explicitly as a normal own data property using `Object.defineProperty`. This preserves the test’s goal (ensuring dangerous keys are sanitized) while removing prototype-assignment ambiguity and satisfying CodeQL.

In `tests/ssr.test.ts`, update the `pollutedState` creation inside the test `"sanitizes dangerous top-level store state keys during serialization"` (around lines 505–510). Replace the current `Object.assign(Object.create(null), { ... ['__proto__']: 'bad' ... })` expression with:
1. Create `pollutedState` as `Object.create(null)`.
2. Assign safe/dangerous plain keys (`safe`, `constructor`, `prototype`) by property assignment.
3. Add `__proto__` using `Object.defineProperty(..., { value: 'bad', enumerable: true, ... })`.

No new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._