### PR TITLE
Fix for Invalid prototype value

### DIFF
--- a/tests/forms.test.ts
+++ b/tests/forms.test.ts
@@ -1038,7 +1038,7 @@ describe('forms/createForm', () => {
       });
       const errors = Object.create(null) as Record<string, string>;
       errors.name = 'Required';
-      Object.defineProperty(errors, '__proto__', { value: 'ignored', enumerable: true });
+      Object.defineProperty(errors, '__proto__', { value: { polluted: true }, enumerable: true });
       Object.defineProperty(errors, 'constructor', { value: 'ignored', enumerable: true });
       Object.defineProperty(errors, 'prototype', { value: 'ignored', enumerable: true });
 


### PR DESCRIPTION
Use a **non-string object value** for the `__proto__` test key so it no longer violates prototype-type expectations, while preserving the test behavior (“ignore pollution keys”).  
Best fix: in `tests/forms.test.ts`, inside the `ignores prototype pollution keys` test, change only the `Object.defineProperty(errors, '__proto__', ...)` value from `'ignored'` to a plain object (for example `{ polluted: true }`). This keeps the key present and enumerable, still exercises defensive handling, and removes the CodeQL complaint about string-as-prototype values.

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._