### PR TITLE
ci: fix Greetings workflow inputs for actions/first-interaction@v3

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 Thanks for opening your first issue in this repository!
 
             To help us respond quickly, please make sure your report includes:
@@ -27,7 +27,7 @@ jobs:
             By participating in this project you agree to follow our community expectations
             and code of conduct (if provided in this repository). Thank you for helping
             improve the project!
-          pr-message: |
+          pr_message: |
             🎉 Thank you for opening your first pull request!
 
             Please confirm that you've reviewed our contribution guidelines:


### PR DESCRIPTION
## Problem
The **Greetings** workflow fails on every first-time issue/PR:

```
Error: Input required and not supplied: issue_message
##[warning]Unexpected input(s) 'repo-token', 'issue-message', 'pr-message',
valid inputs are ['issue_message', 'pr_message', 'repo_token']
```

`actions/first-interaction@v3` renamed its inputs to snake_case, but `.github/workflows/greetings.yml` still passes the old kebab-case names (`repo-token`, `issue-message`, `pr-message`). The action reads them as missing and aborts before posting the greeting.

## Fix
Rename the three inputs to the v3 names: `repo_token`, `issue_message`, `pr_message`. Message content is unchanged.

Surfaced by the Greetings run on #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)