### PR TITLE
fix(build): externalize node:* in the Vite lib build so CLI bundles work

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,12 @@ export default defineConfig({
     minify: 'esbuild',
     target: 'es2020',
     rollupOptions: {
+      // Keep Node built-ins external so the optional CLI entries (view
+      // compiler, i18n extractor) emit real `import('node:fs/promises')`
+      // calls instead of Vite's browser-external stub. Without this, the
+      // bundled CLIs crash at runtime ("e is not a function"). Browser entries
+      // never import `node:*`, so this is a no-op for them.
+      external: (id) => id.startsWith('node:'),
       output: {
         banner,
         // Ensure proper external handling


### PR DESCRIPTION
## Problem

Vite's library build bundled `node:*` imports into its **browser-external stub** (an empty default export). That left `await import('node:fs/promises')` in the optional CLI entry resolving to `undefined`, so the published **`bquery-view-compile`** CLI crashed at runtime with `e is not a function` when run against the `dist` build.

## Fix

Mark `node:*` as external in `rollupOptions` so those imports are emitted verbatim and resolved by Node at runtime:

```ts
rollupOptions: {
  external: (id) => id.startsWith('node:'),
  output: { ... },
}
```

Browser entries never import `node:*`, so this is a no-op for them.

## Verification

- Rebuilt `dist`; the `vite-browser-external` stub is **gone** from `dist/view-compiler.es.mjs` (0 references, was 1).
- `bquery-view-compile --out-dir … file.html` runs end-to-end against the built bundle (`1/1 compiled`).

## Note

This is the standalone hotfix for `dev`. The same one-line change is also present in the stable-graduation PR #157 (which introduces the `bquery-i18n` CLI that surfaced the bug); since the change is byte-identical, the branches reconcile cleanly when both land — or the line can be dropped from #157 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)