### PR TITLE
fix(security): escape mXSS-detection text fallback in sanitizeHtmlCore

### DIFF
--- a/src/security/sanitize-core.ts
+++ b/src/security/sanitize-core.ts
@@ -42,6 +42,23 @@ const isAllowedAttribute = (
 };
 
 /**
+ * Escape HTML entities so text is inert when assigned to an HTML sink.
+ * Local copy to avoid a circular import with `sanitize.ts`.
+ * @internal
+ */
+const escapeHtmlText = (text: string): string => {
+  const escapeMap: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    '`': '&#x60;',
+  };
+  return text.replace(/[&<>"'`]/g, (char) => escapeMap[char]);
+};
+
+/**
  * Check if an ID/name value could cause DOM clobbering.
  * @internal
  */
@@ -356,8 +373,10 @@ export const sanitizeHtmlCore = (html: string, options: SanitizeOptions = {}): s
   // Verify stability: if content mutates between parses, it indicates mXSS attempt
   if (firstPass !== secondPass) {
     // Content mutated during re-parse - potential mXSS detected.
-    // Return safely escaped text content as fallback.
-    return fragment.textContent ?? '';
+    // Callers assign this return value to HTML sinks (innerHTML etc.), so the
+    // text fallback must be HTML-escaped: entity-decoded text nodes can contain
+    // live markup (e.g. `&lt;img onerror=...&gt;` decoded to `<img onerror=...>`).
+    return escapeHtmlText(fragment.textContent ?? '');
   }
 
   return secondPass;

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -92,6 +92,19 @@ describe('security/sanitizeHtml', () => {
     });
     expect(result).not.toContain('data-secret');
   });
+
+  it('escapes the mXSS-detection text fallback (entity-smuggled markup stays inert)', () => {
+    // Foster-parenting makes serialize→re-parse unstable, forcing the mXSS
+    // fallback branch; the entity-encoded payload decodes to live markup in
+    // textContent and must not survive as executable HTML.
+    const payload = '<a><table><a>&lt;img src=x onerror=alert(1)&gt;';
+    const result = String(sanitizeHtml(payload));
+    expect(result).not.toContain('<img');
+
+    const host = document.createElement('div');
+    host.innerHTML = result;
+    expect(host.querySelectorAll('img').length).toBe(0);
+  });
 });
 
 describe('security/escapeHtml', () => {


### PR DESCRIPTION
## Summary
Fixes #162 (Critical).

The anti-mXSS double-parse in `sanitizeHtmlCore` returned **raw, unescaped** `fragment.textContent` when the serialize→re-parse output was unstable. Every caller assigns the return value to an HTML sink (`innerHTML`/`insertAdjacentHTML` via `.html()`, `.append()`, `bq-html`, …), so an attacker could smuggle an entity-encoded payload (`&lt;img src=x onerror=...&gt;`) plus a construct that forces re-parse instability (`<a><table><a>…` foster-parenting) and get live markup back — the mXSS defense itself was the injection sink.

## Fix
The text fallback is now HTML-escaped before being returned (local `escapeHtmlText` helper in `sanitize-core.ts` to avoid a circular import with `sanitize.ts`).

## Verification
- New regression test with the exact audit payload `<a><table><a>&lt;img src=x onerror=alert(1)&gt;`; asserts no `<img>` element materializes when the result is assigned to `innerHTML`.
- Verified the fallback branch actually fires under happy-dom: output is now `&lt;img src=x onerror=alert(1)&gt;` (inert text).
- `bun test tests/security.test.ts`: 59 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)