### PR TITLE
fix(ssr): escape bq-text values on raw-text elements in pure renderer

### DIFF
--- a/src/ssr/renderer.ts
+++ b/src/ssr/renderer.ts
@@ -193,7 +193,10 @@ const stripDirectiveAttributes = (node: SSRNode, prefix: string): void => {
 };
 
 const setText = (el: SSRElement, value: string): void => {
-  el.children = [{ type: 'text', value }];
+  // Raw-text elements (script/style/textarea/title) are serialized verbatim
+  // by serializeTree, so escape here or a value like `</textarea><script>…`
+  // would break out of the element (XSS).
+  el.children = [{ type: 'text', value: el.raw ? escapeText(value) : value }];
 };
 
 /** Recursively collects `<option>` descendants of a virtual `<select>`. */
@@ -232,10 +235,7 @@ const applyModelToPureElement = (el: SSRElement, value: unknown): void => {
       else removeAttr(el, reflection.name);
       break;
     case 'text':
-      // textarea is a raw-text element, so serializeTree emits its text
-      // children verbatim. Escape the reflected value here or a model value
-      // like `</textarea><script>…` would break out of the element (XSS).
-      setText(el, el.raw ? escapeText(reflection.value) : reflection.value);
+      setText(el, reflection.value);
       break;
     case 'select': {
       const options: SSRElement[] = [];

--- a/tests/ssr-stable.test.ts
+++ b/tests/ssr-stable.test.ts
@@ -477,3 +477,38 @@ describe('#129 resumable boundaries — client resume', () => {
     expect(result.wiredHandlers).toBe(0);
   });
 });
+
+describe('#163 bq-text escaping on raw-text elements', () => {
+  for (const backend of BACKENDS) {
+    describe(`backend: ${backend}`, () => {
+      it('escapes bq-text values inside <textarea>', () => {
+        withBackend(backend, () => {
+          const html = renderToString('<textarea bq-text="msg"></textarea>', {
+            msg: '</textarea><img src=x onerror=alert(1)>',
+          }).html;
+          expect(html).not.toContain('<img');
+          expect(html).toContain('&lt;/textarea&gt;');
+        });
+      });
+
+      it('escapes bq-text values inside <title>', () => {
+        withBackend(backend, () => {
+          const html = renderToString('<title bq-text="msg"></title>', {
+            msg: '</title><script>alert(1)</script>',
+          }).html;
+          expect(html).not.toContain('<script>');
+        });
+      });
+
+      it('leaves bq-text on normal elements escaped exactly once', () => {
+        withBackend(backend, () => {
+          const html = renderToString('<p bq-text="msg"></p>', {
+            msg: '<b>&amp;</b>',
+          }).html;
+          expect(html).toContain('&lt;b&gt;');
+          expect(html).not.toContain('&amp;amp;amp;');
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #163 (Critical).

In the default pure SSR renderer, `setText` wrote `bq-text` values verbatim as text children, and `serializeTree` emits text inside raw-text elements (`script`/`style`/`textarea`/`title`) without escaping. An untrusted value like `</textarea><img src=x onerror=alert(1)>` closed the element and injected live markup — stored XSS in the default backend on Node/Bun/Deno.

## Fix
`setText` now escapes via `escapeText` when the target element is raw (`el.raw`), exactly mirroring the pre-existing `bq-model` reflection handling (which already named this hazard). The `bq-model` call site now reuses the centralized logic.

## Verification
- Regression tests for `<textarea bq-text>` and `<title bq-text>` with the audit payloads, run against **both** backends (dom + pure), plus a no-double-escaping check for normal elements.
- Confirmed the new tests fail on the unfixed code (2 failures on the pure backend) and pass with the fix.
- Full SSR suite: 292 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)