### PR TITLE
fix(store): snapshot subscribers before notifying

### DIFF
--- a/src/store/create-store.ts
+++ b/src/store/create-store.ts
@@ -154,7 +154,10 @@ export const createStore = <
     }
 
     const currentState = getCurrentState();
-    for (const callback of subscribers) {
+    // Iterate a snapshot: a callback may unsubscribe (splice) during
+    // notification, which would shift indices under a live iterator and
+    // silently skip the next subscriber. Mirrors the $onAction guard.
+    for (const callback of [...subscribers]) {
       callback(currentState);
     }
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -266,6 +266,23 @@ describe('Store', () => {
       expect(states).toEqual([1]);
     });
 
+    it('does not skip later subscribers when one unsubscribes during notify (#165)', () => {
+      const store = createStore({
+        id: 'counter-unsub-during-notify',
+        state: () => ({ n: 0 }),
+      });
+
+      const unsubA = store.$subscribe(() => unsubA());
+      const seen: string[] = [];
+      store.$subscribe(() => seen.push('B'));
+
+      store.n = 1;
+      expect(seen).toEqual(['B']);
+
+      store.n = 2;
+      expect(seen).toEqual(['B', 'B']);
+    });
+
     it('should not create reactive dependencies when $state is accessed inside effect', () => {
       const store = createStore({
         id: 'counter',


### PR DESCRIPTION
## Summary
Fixes #165 (High).

`notifySubscribers` iterated the live `subscribers` array while unsubscribe `splice`s it, so a self-detaching watcher caused the next subscriber to be silently skipped for that notification cycle.

## Fix
Iterate a snapshot (`[...subscribers]`), mirroring the existing `$onAction` listener-snapshot guard in the same file.

## Verification
- Regression test with the exact issue repro (subscriber A self-unsubscribes, subscriber B must still fire); fails without the fix, passes with it.
- `bun test tests/store.test.ts`: 95 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)