### PR TITLE
fix(view): shadow dangerous globals in with-scoped evaluator

### DIFF
--- a/src/view/evaluate.ts
+++ b/src/view/evaluate.ts
@@ -135,12 +135,69 @@ export const clearExpressionCache = (): void => {
  * This avoids subscribing to signals that aren't referenced in the expression.
  * @internal
  */
+/**
+ * Identifiers that must never resolve during `with`-scoped evaluation.
+ *
+ * `with` resolves a free identifier via `[[HasProperty]]`, walking the
+ * prototype chain. If the context proxy declines an inherited name, resolution
+ * falls through to the function's enclosing scope — and the global object
+ * itself inherits `constructor` from `Object.prototype` and exposes `Function`,
+ * `eval`, `globalThis`, `window`, etc. So `constructor.constructor('…')()` (or
+ * a bare `Function('…')()`) would still reach arbitrary code execution.
+ *
+ * These names are therefore *shadowed*: the proxy claims to own them (`has`
+ * returns true) but resolves them to `undefined` (`get` returns undefined),
+ * unless the context legitimately defines its own property of that name. Any
+ * member access on the resulting `undefined` throws and evaluates to
+ * `undefined`.
+ * @internal
+ */
+const SHADOWED_GLOBALS = new Set([
+  'constructor',
+  '__proto__',
+  'prototype',
+  'Function',
+  'eval',
+  'globalThis',
+  'global',
+  'window',
+  'self',
+  'top',
+  'parent',
+]);
+
+/**
+ * `has` trap for `with`-scoped evaluation proxies. Reports own string keys and
+ * the shadowed dangerous globals as present so neither resolves from an
+ * inherited prototype member or the enclosing (global) scope.
+ *
+ * Symbol keys keep default behaviour so `with`'s internal `Symbol.unscopables`
+ * probe still works.
+ * @internal
+ */
+const hardenedHas = (target: BindingContext, prop: string | symbol): boolean => {
+  if (typeof prop !== 'string') {
+    return Reflect.has(target, prop);
+  }
+  return Object.prototype.hasOwnProperty.call(target, prop) || SHADOWED_GLOBALS.has(prop);
+};
+
+/**
+ * Returns true when `prop` is a shadowed global the context does not itself own.
+ * @internal
+ */
+const isShadowedGlobal = (target: BindingContext, prop: string): boolean =>
+  SHADOWED_GLOBALS.has(prop) && !Object.prototype.hasOwnProperty.call(target, prop);
+
 const createLazyContext = (context: BindingContext): BindingContext =>
   new Proxy(context, {
     get(target, prop: string | symbol) {
       // Only handle string keys for BindingContext indexing
       if (typeof prop !== 'string') {
         return Reflect.get(target, prop);
+      }
+      if (isShadowedGlobal(target, prop)) {
+        return undefined;
       }
       const value = target[prop];
       // Auto-unwrap signals/computed only when actually accessed
@@ -149,13 +206,24 @@ const createLazyContext = (context: BindingContext): BindingContext =>
       }
       return value;
     },
-    has(target, prop: string | symbol) {
-      // Required for `with` statement to resolve identifiers correctly
-      if (typeof prop !== 'string') {
-        return Reflect.has(target, prop);
+    has: hardenedHas,
+  });
+
+/**
+ * Wraps a raw context so `with`-based evaluation cannot resolve inherited
+ * prototype members or dangerous globals, without unwrapping signals
+ * (unlike {@link createLazyContext}).
+ * @internal
+ */
+const createHardenedContext = (context: BindingContext): BindingContext =>
+  new Proxy(context, {
+    get(target, prop: string | symbol) {
+      if (typeof prop === 'string' && isShadowedGlobal(target, prop)) {
+        return undefined;
       }
-      return prop in target;
+      return Reflect.get(target, prop);
     },
+    has: hardenedHas,
   });
 
 /**
@@ -221,13 +289,15 @@ export const evaluateRaw = <T = unknown>(expression: string, context: BindingCon
     let fn = evaluateRawCache.get(expression);
     if (!fn) {
       // Use `with` to enable direct property access from context scope.
-      // Unlike `evaluate`, we don't use a lazy proxy - values are accessed directly.
+      // Unlike `evaluate`, we don't unwrap signals — but we still wrap the
+      // context in a hardened proxy so `with` cannot resolve inherited
+      // prototype members (e.g. `constructor.constructor`).
       fn = new Function('$ctx', `with($ctx) { return (${expression}); }`) as (
         ctx: BindingContext
       ) => unknown;
       evaluateRawCache.set(expression, fn);
     }
-    return fn(context) as T;
+    return fn(createHardenedContext(context)) as T;
   } catch (error) {
     console.error(`bQuery view: Error evaluating "${expression}"`, error);
     return undefined as T;

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1427,18 +1427,18 @@ describe('evaluate — prototype-chain hardening (#168)', () => {
   });
 
   it('lets an own context property shadow a dangerous global name', () => {
-    expect(evaluate('constructor', { constructor: 'mine' })).toBe('mine');
+    expect(evaluate<string>('constructor', { constructor: 'mine' })).toBe('mine');
   });
 
   it('still resolves own context properties', () => {
-    expect(evaluate('a + b', { a: 2, b: 3 })).toBe(5);
+    expect(evaluate<number>('a + b', { a: 2, b: 3 })).toBe(5);
   });
 
   it('still allows method calls on context values (inherited on the value, not the context)', () => {
-    expect(evaluate('name.toUpperCase()', { name: 'ada' })).toBe('ADA');
+    expect(evaluate<string>('name.toUpperCase()', { name: 'ada' })).toBe('ADA');
   });
 
   it('resolves own properties that shadow prototype names', () => {
-    expect(evaluate('hasOwnProperty', { hasOwnProperty: 42 })).toBe(42);
+    expect(evaluate<number>('hasOwnProperty', { hasOwnProperty: 42 })).toBe(42);
   });
 });

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -5,7 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn, type Mock } from 'bun:test';
 import { createForm, required } from '../src/forms/index';
 import { computed, signal } from '../src/reactive/index';
-import { parseObjectExpression } from '../src/view/evaluate';
+import { evaluate, evaluateRaw, parseObjectExpression } from '../src/view/evaluate';
 import { clearExpressionCache, createTemplate, mount, type View } from '../src/view/index';
 import { getCustomDirective, registerCustomDirectiveResolver } from '../src/view/custom-directives';
 
@@ -1399,5 +1399,46 @@ describe('parseObjectExpression', () => {
     expect(Object.prototype.hasOwnProperty.call(result, 'constructor')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(result, 'prototype')).toBe(false);
     expect(Object.keys(result)).toEqual(['safe']);
+  });
+});
+
+describe('evaluate — prototype-chain hardening (#168)', () => {
+  const originalError = console.error;
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  it('does not resolve inherited constructor via the with-scoped proxy', () => {
+    console.error = () => {};
+    const result = evaluate("constructor.constructor('return 1')()", {});
+    expect(result).toBeUndefined();
+  });
+
+  it('does not reach Function through evaluateRaw either', () => {
+    console.error = () => {};
+    const result = evaluateRaw("constructor.constructor('return 1')()", {});
+    expect(result).toBeUndefined();
+  });
+
+  it('shadows the bare Function and eval globals', () => {
+    console.error = () => {};
+    expect(evaluate("Function('return 1')()", {})).toBeUndefined();
+    expect(evaluate("eval('1')", {})).toBeUndefined();
+  });
+
+  it('lets an own context property shadow a dangerous global name', () => {
+    expect(evaluate('constructor', { constructor: 'mine' })).toBe('mine');
+  });
+
+  it('still resolves own context properties', () => {
+    expect(evaluate('a + b', { a: 2, b: 3 })).toBe(5);
+  });
+
+  it('still allows method calls on context values (inherited on the value, not the context)', () => {
+    expect(evaluate('name.toUpperCase()', { name: 'ada' })).toBe('ADA');
+  });
+
+  it('resolves own properties that shadow prototype names', () => {
+    expect(evaluate('hasOwnProperty', { hasOwnProperty: 42 })).toBe(42);
   });
 });


### PR DESCRIPTION
## Summary
Fixes #168 (Medium hardening).

`evaluate`/`evaluateRaw` run `new Function('$ctx', 'with($ctx){ return (expr); }')`. The proxy `has` trap returned `prop in target`, so inherited `Object.prototype` members resolved from the context and `constructor.constructor('…')()` reached the `Function` constructor — arbitrary code execution wherever `bq-*` attributes carry untrusted content.

## Fix
The issue's suggested own-keys-only `has` trap is necessary but **not sufficient**: once the proxy declines `constructor`, `with` resolution falls through to the enclosing global scope, where the global object inherits `constructor` from `Object.prototype` and exposes `Function`/`eval`/`globalThis`. A bare `Function('…')()` escapes the same way.

So the evaluator now **shadows** a denylist (`constructor`, `__proto__`, `prototype`, `Function`, `eval`, `globalThis`, `global`, `window`, `self`, `top`, `parent`): `has` reports them present (so they never fall through to the global scope) and `get` resolves them to `undefined` unless the context legitimately owns that property. Member access on the resulting `undefined` throws → `undefined`. Both the lazy (`evaluate`) and raw (`evaluateRaw`) paths are covered.

Legitimate templates are unaffected: own context props (including ones shadowing a dangerous name), arithmetic, and method calls on context *values* (e.g. `name.toUpperCase()`) all still work.

## Verification
- Tests: `constructor.constructor(…)()` on both `evaluate` and `evaluateRaw`, bare `Function(…)()` and `eval(…)`, plus positive cases (own props, method calls, own-prop shadowing a global name). The exploit tests fail on the pre-fix code.
- Full suite: 2993 pass / 0 fail. `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)