### PR TITLE
fix(server): default session and CSRF cookies to Secure

### DIFF
--- a/src/server/csrf.ts
+++ b/src/server/csrf.ts
@@ -33,9 +33,11 @@ export interface CsrfOptions {
   /** Form/JSON body field carrying the token when no header is present. Default `'_csrf'`. */
   fieldName?: string;
   /**
-   * Cookie attributes. Defaults to `{ sameSite: 'lax', path: '/' }`. The cookie
-   * is readable by client JS by default (plain double-submit); set
+   * Cookie attributes. Defaults to `{ sameSite: 'lax', path: '/', secure: true }`.
+   * The cookie is readable by client JS by default (plain double-submit); set
    * `httpOnly: true` only when you deliver the token out-of-band (signed mode).
+   * `secure` defaults to `true` (in signed mode the token embeds the raw
+   * secret); set `secure: false` for local HTTP dev.
    */
   cookie?: ServerCookieOptions;
   /** HTTP methods that skip verification. Default `['GET', 'HEAD', 'OPTIONS']`. */
@@ -160,6 +162,9 @@ export const csrf = (options: CsrfOptions = {}): ServerMiddleware => {
     sameSite: 'lax',
     path: '/',
     ...options.cookie,
+    // In signed mode the token embeds the raw secret, so default `Secure` to
+    // keep it off plaintext HTTP. Opt out explicitly for local HTTP dev.
+    secure: options.cookie?.secure ?? true,
   };
 
   const tokenFor = async (secret: string): Promise<string> =>

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -60,8 +60,11 @@ export interface SessionOptions {
   /** Cookie name. Default `'bq.sid'`. */
   cookieName?: string;
   /**
-   * Cookie attributes. Defaults to `{ httpOnly: true, sameSite: 'lax', path: '/' }`.
-   * Set `secure: true` in production (HTTPS). `maxAge` is derived from `ttlMs`.
+   * Cookie attributes. Defaults to
+   * `{ httpOnly: true, sameSite: 'lax', path: '/', secure: true }`.
+   * `secure` defaults to `true` (session credential must not travel over
+   * plaintext HTTP); set `secure: false` for local HTTP dev. `maxAge` is
+   * derived from `ttlMs`.
    */
   cookie?: ServerCookieOptions;
   /** Session lifetime in milliseconds. Default `86_400_000` (1 day). */
@@ -303,6 +306,10 @@ export const session = (options: SessionOptions): ServerMiddleware => {
     sameSite: 'lax',
     path: '/',
     ...options.cookie,
+    // The session cookie is the sole bearer credential, so default `Secure`
+    // to keep it off plaintext HTTP. Opt out explicitly (`secure: false`) for
+    // local HTTP dev.
+    secure: options.cookie?.secure ?? true,
   };
   const maxAge = Number.isFinite(ttlMs) && ttlMs > 0 ? Math.floor(ttlMs / 1000) : undefined;
 

--- a/tests/server-stable.test.ts
+++ b/tests/server-stable.test.ts
@@ -176,6 +176,19 @@ describe('server/session', () => {
     expect(attributes).toContain('HttpOnly');
     expect(attributes).toContain('SameSite=Lax');
     expect(attributes).toContain('Path=/');
+    expect(attributes).toContain('Secure');
+  });
+
+  it('allows opting out of Secure for local HTTP dev (#169)', async () => {
+    const store = memoryStore();
+    const app = createServer();
+    app.use(session({ secret: SECRET, store, cookie: { secure: false } }));
+    app.post('/login', (ctx) => {
+      ctx.session!.userId = 'u_1';
+      return ctx.json({ ok: true });
+    });
+    const login = await app.handle({ url: '/login', method: 'POST' });
+    expect(setCookieAttributes(login, 'bq.sid')).not.toContain('Secure');
   });
 
   it('ignores a tampered session cookie', async () => {
@@ -345,6 +358,24 @@ describe('server/csrf', () => {
     expect(typeof body.token).toBe('string');
     expect(body.token.length).toBeGreaterThan(0);
     expect(() => cookiePair(res, 'bq.csrf')).not.toThrow();
+  });
+
+  it('marks the CSRF secret cookie Secure by default (#169)', async () => {
+    const app = createServer();
+    app.use(csrf({ secret: SECRET }));
+    app.get('/token', (ctx) => ctx.json({ token: csrfToken(ctx) }));
+
+    const res = await app.handle('/token');
+    expect(setCookieAttributes(res, 'bq.csrf')).toContain('Secure');
+  });
+
+  it('allows opting out of Secure on the CSRF cookie (#169)', async () => {
+    const app = createServer();
+    app.use(csrf({ secret: SECRET, cookie: { secure: false } }));
+    app.get('/token', (ctx) => ctx.json({ token: csrfToken(ctx) }));
+
+    const res = await app.handle('/token');
+    expect(setCookieAttributes(res, 'bq.csrf')).not.toContain('Secure');
   });
 
   it('rejects unsafe requests without a token', async () => {


### PR DESCRIPTION
## Summary
Fixes #169 (Medium; direct credential-theft impact).

The session-id cookie (the sole bearer credential) and the CSRF secret cookie (embeds the raw secret in signed mode) both defaulted to **no `Secure`** flag. On any plaintext-HTTP hop — an HTTP→HTTPS redirect, a misconfigured proxy — a network MITM could read them and hijack the session or forge matching CSRF tokens. `sameSite: 'lax'` does not compensate.

## Fix
Both middlewares now default `secure: true` with an explicit opt-out for local HTTP dev:
```ts
secure: options.cookie?.secure ?? true
```
Placed after the `...options.cookie` spread so a user's explicit `secure: false` still wins. Session (`session.ts`, including the destroy/expire path via shared `baseCookie`) and CSRF (`csrf.ts`) are covered. Doc comments updated.

## Verification
- Strengthened the existing "secure-by-default" session test (it never actually asserted `Secure`) + new opt-out test.
- New CSRF tests: `Secure` present by default, absent when `secure: false`.
- `bun test` server suites: all pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)