### PR TITLE
fix(reactive): abort superseded in-flight fetch on overlapping execute

### DIFF
--- a/src/reactive/async-data.ts
+++ b/src/reactive/async-data.ts
@@ -508,7 +508,12 @@ export const useFetch = <TResponse = unknown, TData = TResponse>(
     const retryConfig = normalizeRetryConfig(options.retry);
     const maxAttempts = (retryConfig?.count ?? 0) + 1;
 
-    // Abort controller: compose timeout + external signal + manual abort
+    // Abort controller: compose timeout + external signal + manual abort.
+    // Abort any still-in-flight controller from a superseded execution first —
+    // overlapping executes (e.g. a watch refresh racing a manual refresh())
+    // would otherwise leave the earlier fetch running, un-cancellable, until it
+    // resolves (only its result is discarded by the executionId guard).
+    currentAbortController?.abort();
     const abortController = new AbortController();
     currentAbortController = abortController;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/tests/signal.test.ts
+++ b/tests/signal.test.ts
@@ -1223,6 +1223,42 @@ describe('useFetch', () => {
     expect(requests).toHaveLength(1);
   });
 
+  it('aborts a superseded in-flight request when a new execution starts (#172)', async () => {
+    const signals: AbortSignal[] = [];
+    let releaseFirst: (() => void) | undefined;
+
+    const state = useFetch<{ ok: boolean }>('/api/slow', {
+      immediate: false,
+      fetcher: asMockFetch((_input, init) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (signal) signals.push(signal);
+        return new Promise<Response>((resolve, reject) => {
+          if (signal) {
+            signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+          }
+          // The first request hangs until released; the second resolves.
+          if (!releaseFirst) {
+            releaseFirst = () => resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+          } else {
+            resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+          }
+        });
+      }),
+    });
+
+    // Start two overlapping executions; the second must abort the first.
+    const first = state.execute().catch(() => undefined);
+    const second = state.execute();
+
+    await second;
+    expect(signals).toHaveLength(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+
+    releaseFirst?.();
+    await first;
+  });
+
   it('serializes plain object bodies as JSON', async () => {
     let body = '';
     let contentType = '';


### PR DESCRIPTION
## Summary
Fixes #172 (Medium; correctness / resource exhaustion).

`useFetch` kept a single shared `currentAbortController` and overwrote it on every `execute()`. When executions overlap (a `watch` refresh racing a manual `refresh()`/`execute()`), the earlier in-flight fetch was **never aborted** — its result was discarded by the `executionId` guard, but the request kept consuming network/CPU, and `state.abort()` could only cancel the most recent controller. Rapid `watch` churn piled up un-cancellable requests.

## Fix
`execute()` aborts the previous controller (`currentAbortController?.abort()`) before creating the new one. The superseded request is cancelled immediately. The existing `finally` cleanup already only nulls the controller when it's still the current one, so no cross-execution clobbering.

## Verification
- New test: two overlapping executions; the first request's `AbortSignal` becomes `aborted`, the second stays live. Fails without the fix.
- Reactive/http/network/concurrency suites: 335 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)