### PR TITLE
fix(i18n): use own-property checks for placeholder and key resolution

### DIFF
--- a/src/i18n/icu.ts
+++ b/src/i18n/icu.ts
@@ -51,6 +51,14 @@ export const isICUMessage = (template: string): boolean =>
 const isNameChar = (ch: string): boolean => /[A-Za-z0-9_]/.test(ch);
 
 /**
+ * Own-property check for argument lookup, so a placeholder name colliding with
+ * an inherited `Object.prototype` member (`toString`, `constructor`, …) is not
+ * treated as present.
+ */
+const hasParam = (params: TranslateParams, name: string): boolean =>
+  Object.prototype.hasOwnProperty.call(params, name);
+
+/**
  * Parses a message pattern starting at `pos`, stopping at the first
  * unbalanced `}` (when nested inside an argument) or end of input.
  *
@@ -277,18 +285,18 @@ const render = (
         break;
 
       case 'arg':
-        out += node.name in params ? String(params[node.name]) : `{${node.name}}`;
+        out += hasParam(params, node.name) ? String(params[node.name]) : `{${node.name}}`;
         break;
 
       case 'select': {
-        const value = node.name in params ? String(params[node.name]) : 'other';
+        const value = hasParam(params, node.name) ? String(params[node.name]) : 'other';
         const chosen = node.cases.get(value) ?? node.cases.get('other') ?? [];
         out += render(chosen, params, locale, poundValue);
         break;
       }
 
       case 'plural': {
-        const raw = Number(params[node.name]);
+        const raw = hasParam(params, node.name) ? Number(params[node.name]) : NaN;
         const value = Number.isFinite(raw) ? raw : 0;
         const adjusted = value - node.offset;
 

--- a/src/i18n/translate.ts
+++ b/src/i18n/translate.ts
@@ -23,6 +23,9 @@ export const resolveKey = (messages: LocaleMessages, key: string): string | unde
 
   for (const part of parts) {
     if (typeof current === 'string') return undefined;
+    // Own-property check: never resolve inherited prototype members
+    // (`toString`, `constructor`, `__proto__`, …) as message segments.
+    if (!Object.prototype.hasOwnProperty.call(current, part)) return undefined;
     if (current[part] === undefined) return undefined;
     current = current[part];
   }
@@ -47,7 +50,10 @@ export const resolveKey = (messages: LocaleMessages, key: string): string | unde
  */
 export const interpolate = (template: string, params: TranslateParams): string => {
   return template.replace(/\{(\w+)\}/g, (match, key: string) => {
-    if (key in params) {
+    // Own-property check so a placeholder colliding with an inherited member
+    // (`toString`, `valueOf`, …) is left intact rather than substituted with
+    // the inherited value.
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
       return String(params[key]);
     }
     return match; // Leave unmatched placeholders as-is

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -666,3 +666,25 @@ describe('i18n/module exports', () => {
     expect(typeof mod.formatDate).toBe('function');
   });
 });
+
+describe('i18n prototype-chain hardening (#174)', () => {
+  it('leaves a placeholder colliding with an Object.prototype member intact', async () => {
+    const { interpolate } = await import('../src/i18n/translate');
+    expect(interpolate('Hello {toString}', {})).toBe('Hello {toString}');
+    expect(interpolate('X {constructor} Y', {})).toBe('X {constructor} Y');
+    // A real param still substitutes.
+    expect(interpolate('Hello {toString}', { toString: 'ok' })).toBe('Hello ok');
+  });
+
+  it('does not resolve inherited members as message key segments', async () => {
+    const { resolveKey } = await import('../src/i18n/translate');
+    expect(resolveKey({ greeting: 'hi' }, 'toString')).toBeUndefined();
+    expect(resolveKey({ greeting: 'hi' }, 'constructor.name')).toBeUndefined();
+  });
+
+  it('leaves ICU arg/select placeholders intact for inherited names', async () => {
+    const { formatMessage } = await import('../src/i18n/define');
+    expect(formatMessage('{toString}', {})).toBe('{toString}');
+    expect(formatMessage('{hasOwnProperty, select, other {none}}', {})).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #174 (Low; contract violation + minor info-shape leak).

`interpolate` and the ICU `arg`/`select`/`plural` sites used the `in` operator (and `resolveKey` walked key segments without a guard), which resolves inherited `Object.prototype` members. A placeholder or key matching `toString`/`valueOf`/`constructor`/`__proto__`/… was treated as present even when `params`/`messages` didn't own it, substituting the inherited value (e.g. `Hello {toString}` → the native function source) instead of leaving the literal `{name}` intact.

## Fix
All lookup sites use `Object.prototype.hasOwnProperty.call(...)`:
- `translate.ts`: `interpolate` placeholder check + defensive guard in `resolveKey`
- `icu.ts`: shared `hasParam()` helper used by the `arg`, `select`, and `plural` cases

## Verification
- New tests: `{toString}`/`{constructor}` placeholders left intact; real params still substitute; `resolveKey` returns `undefined` for inherited names; ICU `arg`/`select` unaffected by inherited names. All three fail on the pre-fix code.
- i18n suites: 110 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
