### PR TITLE
fix(store): guard deepClone against __proto__ key reassignment

### DIFF
--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { detectDevEnvironment } from '../core/env';
+import { isPrototypePollutionKey } from '../core/utils/object';
 
 /**
  * Check if a value is a plain object (not array, null, Date, etc.).
@@ -42,6 +43,10 @@ export const deepClone = <T>(obj: T): T => {
 
   const cloned = {} as T;
   for (const key of Object.keys(obj)) {
+    // Skip prototype-pollution keys: an own enumerable `__proto__` (e.g. from
+    // JSON.parse('{"__proto__":{…}}')) would otherwise trigger the setter and
+    // reassign the clone's prototype instead of copying a data property.
+    if (isPrototypePollutionKey(key)) continue;
     (cloned as Record<string, unknown>)[key] = deepClone((obj as Record<string, unknown>)[key]);
   }
   return cloned;

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -632,6 +632,23 @@ describe('Store', () => {
     });
   });
 
+  describe('deepClone prototype-pollution guard (#175)', () => {
+    it('does not reassign the clone prototype for an own __proto__ key', async () => {
+      const { deepClone } = await import('../src/store/utils');
+      // JSON.parse produces an own, enumerable `__proto__` data property.
+      const malicious = JSON.parse('{"__proto__":{"polluted":true},"safe":1}') as Record<
+        string,
+        unknown
+      >;
+
+      const cloned = deepClone(malicious);
+
+      expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype);
+      expect((cloned as { safe: number }).safe).toBe(1);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+
   describe('$onAction', () => {
     it('should call the listener before each action', () => {
       const store = createStore<


### PR DESCRIPTION
## Summary
Fixes #175 (Low; robustness).

The store's `deepClone` assigned via bracket notation over `Object.keys`, so a state object with an own enumerable `__proto__` key (e.g. from `JSON.parse('{"__proto__":{…}}')`) triggered the `__proto__` setter and reassigned the **clone's** prototype instead of copying a data property, corrupting the object `$patchDeep` operates on. Contained (no global `Object.prototype` pollution) but a fidelity bug.

## Fix
`deepClone` skips prototype-pollution keys via the shared `isPrototypePollutionKey` helper from `core/utils/object.ts` (already used by `merge`).

## Verification
- New test: cloning a `JSON.parse`'d `{"__proto__":{polluted:true},"safe":1}` yields a clone whose prototype is still `Object.prototype`, preserves `safe`, and does not pollute `{}`. Fails on the pre-fix code.
- Store suite: 95 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
