### PR TITLE
fix(ssr): validate bq-style declarations in the pure renderer

### DIFF
--- a/src/ssr/renderer.ts
+++ b/src/ssr/renderer.ts
@@ -137,13 +137,25 @@ const setClass = (el: SSRElement, cls: string): void => {
   el.attributes['class'] = merged;
 };
 
+// A CSS property name: standard kebab-case identifiers or `--custom-props`.
+const SAFE_STYLE_PROP = /^(?:--[\w-]+|-?[a-z][a-z0-9-]*)$/;
+// Characters that would let an untrusted value break out of its declaration and
+// inject additional declarations or rules.
+const UNSAFE_STYLE_VALUE = /[;{}<]/;
+
 const setStyle = (el: SSRElement, declarations: Record<string, unknown>): void => {
   let css = el.attributes['style'] ?? '';
   for (const [prop, val] of Object.entries(declarations)) {
     if (val === undefined || val === null || val === false) continue;
     const cssProp = prop.replace(/([A-Z])/g, '-$1').toLowerCase();
+    const value = String(val);
+    // Drop declarations whose property or value could inject extra CSS
+    // (e.g. a value like `x;} body{display:none`). The value is only
+    // attribute-escaped on serialize, which stops HTML breakout but not the
+    // injection of sibling declarations/rules within the style attribute.
+    if (!SAFE_STYLE_PROP.test(cssProp) || UNSAFE_STYLE_VALUE.test(value)) continue;
     if (css && !css.endsWith(';')) css += '; ';
-    css += `${cssProp}: ${String(val)};`;
+    css += `${cssProp}: ${value};`;
   }
   if (!('style' in el.attributes)) el.attributeOrder.push('style');
   el.attributes['style'] = css;

--- a/tests/ssr-stable.test.ts
+++ b/tests/ssr-stable.test.ts
@@ -498,6 +498,12 @@ describe('#176 bq-style CSS injection guard', () => {
           }).html;
           expect(html).toContain('color: red');
           expect(html).toContain('margin-top: 4px');
+        });
+      });
+    });
+  }
+});
+
 describe('#163 bq-text escaping on raw-text elements', () => {
   for (const backend of BACKENDS) {
     describe(`backend: ${backend}`, () => {

--- a/tests/ssr-stable.test.ts
+++ b/tests/ssr-stable.test.ts
@@ -477,3 +477,29 @@ describe('#129 resumable boundaries — client resume', () => {
     expect(result.wiredHandlers).toBe(0);
   });
 });
+
+describe('#176 bq-style CSS injection guard', () => {
+  for (const backend of BACKENDS) {
+    describe(`backend: ${backend}`, () => {
+      it('drops style values that try to inject extra declarations', () => {
+        withBackend(backend, () => {
+          const html = renderToString('<div bq-style="styles"></div>', {
+            styles: { width: 'x;} body{display:none' },
+          }).html;
+          expect(html).not.toContain('display:none');
+          expect(html).not.toContain('body{');
+        });
+      });
+
+      it('keeps safe style declarations', () => {
+        withBackend(backend, () => {
+          const html = renderToString('<div bq-style="styles"></div>', {
+            styles: { color: 'red', marginTop: '4px' },
+          }).html;
+          expect(html).toContain('color: red');
+          expect(html).toContain('margin-top: 4px');
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #176 (Low; CSS injection — no HTML breakout).

The DOM-free `setStyle` concatenated `bq-style` property names and values into the inline `style` attribute with no CSS-level validation. Attribute escaping prevents HTML breakout, but an untrusted style value like `x;} body{display:none` injected extra declarations/rules (UI-redress/clickjacking, exfiltration via `background: url(...)`).

## Fix
`setStyle` (pure renderer) now drops any declaration whose property name is not a valid CSS identifier (`--custom` or kebab-case) or whose value contains injection characters (`;`, `{`, `}`, `<`). The DOM-backed renderer was already safe — it writes via `CSSStyleDeclaration.setProperty`, which rejects malformed values.

## Verification
- New tests across both backends: a malicious `width: 'x;} body{display:none'` is dropped; safe declarations (`color`, `marginTop`) pass through. The malicious case fails on the pre-fix pure renderer.
- SSR suites: all pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
