### PR TITLE
fix(ssr): insert titleTemplate title literally

### DIFF
--- a/src/ssr/head.ts
+++ b/src/ssr/head.ts
@@ -112,7 +112,10 @@ export const createHeadManager = (): HeadManager => {
     let html = '';
     if (state.title !== null) {
       const formatted = state.titleTemplate
-        ? state.titleTemplate.replace(/%s/g, state.title)
+        ? // Use a replacer function so the title is inserted literally — a bare
+          // replacement string would interpret `$&`/`$1`/`` $` ``/`$'` in the
+          // title as special replacement patterns and mangle the output.
+          state.titleTemplate.replace(/%s/g, () => state.title as string)
         : state.title;
       html += `<title>${escapeText(formatted)}</title>`;
     }

--- a/tests/ssr-runtime.test.ts
+++ b/tests/ssr-runtime.test.ts
@@ -857,6 +857,15 @@ describe('head manager', () => {
     head.add({ title: 'Home', titleTemplate: '%s | Acme' });
     expect(head.render()).toContain('<title>Home | Acme</title>');
   });
+
+  it('inserts a title with special replacement patterns literally (#177)', () => {
+    const head = createHeadManager();
+    head.add({ title: 'Q&A $& more', titleTemplate: '%s | Acme' });
+    // `$&` in the title must not be interpreted as a replacement pattern.
+    // escapeText encodes the ampersands, so assert the literal `$&` survives.
+    expect(head.render()).toContain('$&amp; more');
+    expect(head.render()).toContain('| Acme');
+  });
 });
 
 describe('asset manager', () => {


### PR DESCRIPTION
## Summary
Fixes #177 (Low; correctness — not exploitable).

`titleTemplate` was applied with `state.titleTemplate.replace(/%s/g, state.title)`. Because the title is the **replacement string**, special replacement patterns (`$&`, `$1`, `` $` ``, `$'`) in the title were interpreted by `String.prototype.replace` and mangled the output — e.g. a page titled `Q&A $& more` rendered incorrectly.

## Fix
Use a replacer **function** (`() => state.title`) so the title is inserted literally. Output is still `escapeText`'d as before.

## Verification
- New test: a title containing `$&` renders literally under a `%s | Acme` template. Fails on the pre-fix code.
- ssr-runtime suite: 107 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
