### PR TITLE
fix(core): stop debounce double-invoking a single leading+trailing call

### DIFF
--- a/src/core/utils/function.ts
+++ b/src/core/utils/function.ts
@@ -112,7 +112,11 @@ export function debounce<TArgs extends unknown[]>(
     const now = Date.now();
     if (leading && !leadingDone) {
       leadingDone = true;
-      invoke(args, trailing, now);
+      // Clear pendingArgs on the leading invoke so a SINGLE call does not also
+      // fire the trailing edge. A subsequent call within the window re-sets
+      // pendingArgs (the leading branch is skipped), so the trailing edge still
+      // fires when the function was called more than once (lodash semantics).
+      invoke(args, false, now);
     }
     clearTrailing();
     timeoutId = setTimeout(trailingTrigger, delayMs);

--- a/tests/utils-function-extras.test.ts
+++ b/tests/utils-function-extras.test.ts
@@ -121,15 +121,17 @@ describe('utils/function extras', () => {
     expect(calls).toEqual([1, 3]);
   });
 
-  it('debounce(leading: true, trailing: true) keeps a single call for the trailing edge', async () => {
+  it('debounce(leading: true, trailing: true) does not double-invoke a single call (#178)', async () => {
     const calls: number[] = [];
     const fn = debounce((n: number) => calls.push(n), 30, { leading: true, trailing: true });
 
     fn(1);
 
+    // Leading fires immediately; the trailing edge must NOT fire for a single
+    // call (lodash semantics: trailing only when called more than once).
     expect(calls).toEqual([1]);
     await wait(60);
-    expect(calls).toEqual([1, 1]);
+    expect(calls).toEqual([1]);
   });
 
   it('debounce maxWait forces invocation', async () => {


### PR DESCRIPTION
## Summary
Fixes #178 (Low; correctness).

With `{ leading: true, trailing: true }`, a **single** call double-invoked: the leading branch invoked with `preservePending = trailing` (keeping `pendingArgs`), then `trailingTrigger` saw `pendingArgs` still set and invoked again. One call → two invocations.

## Fix
The leading invoke now clears `pendingArgs`. A subsequent call within the window re-sets `pendingArgs` (the leading branch is skipped once `leadingDone`), so the trailing edge still fires — but only when the function was called more than once, matching lodash semantics.

## Verification
- Existing multi-call test (`fn(1); fn(2); fn(3)` → `[1, 3]`) still passes.
- Rewrote the single-call test that previously codified the bug: `fn(1)` now yields `[1]`, not `[1, 1]`. It fails on the pre-fix code.
- function/utils/core suites: all pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
