### PR TITLE
fix(security): strengthen DOM-clobbering defenses

### DIFF
--- a/src/security/constants.ts
+++ b/src/security/constants.ts
@@ -128,6 +128,13 @@ export const DANGEROUS_TAGS = new Set([
 /**
  * Reserved IDs that could cause DOM clobbering attacks.
  * These are prevented to avoid overwriting global browser objects.
+ *
+ * This is defense-in-depth, not a complete guarantee: named-property access
+ * on `window`/`document`/`HTMLFormElement` can be clobbered by arbitrary
+ * `id`/`name` values, so this denylist only blocks the highest-value targets.
+ * For fully untrusted content prefer dropping `id`/`name` entirely (or
+ * namespacing them). Duplicate-`id` HTMLCollection clobbering is additionally
+ * mitigated in `sanitize-core.ts`.
  */
 export const RESERVED_IDS = new Set([
   // Global objects
@@ -141,31 +148,73 @@ export const RESERVED_IDS = new Set([
   'history',
   'navigator',
   'screen',
+  'globalthis',
+  'defaultview',
+  'opener',
+  'length',
+  'origin',
+  'name',
   // Dangerous functions
   'alert',
   'confirm',
   'prompt',
   'eval',
   'function',
-  // Document properties
+  // Document properties / methods
   'cookie',
   'domain',
   'referrer',
   'body',
   'head',
+  'title',
   'forms',
   'images',
   'links',
   'scripts',
+  'anchors',
+  'embeds',
+  'plugins',
+  'implementation',
+  'documentelement',
+  'activeelement',
+  'getelementbyid',
+  'getelementsbyname',
+  'getelementsbytagname',
+  'getelementsbyclassname',
+  'queryselector',
+  'queryselectorall',
+  'createelement',
+  'write',
+  'writeln',
+  // Node / Element properties
+  'attributes',
+  'nodename',
+  'nodetype',
+  'nodevalue',
+  'ownerdocument',
+  'classlist',
+  'dataset',
+  'style',
+  'id',
   // DOM traversal properties
   'children',
+  'childnodes',
   'parentnode',
+  'parentelement',
   'firstchild',
   'lastchild',
+  'firstelementchild',
+  'lastelementchild',
+  'nextsibling',
+  'previoussibling',
+  'nextelementsibling',
+  'previouselementsibling',
   // Content manipulation
   'innerhtml',
   'outerhtml',
+  'innertext',
   'textcontent',
+  'insertadjacenthtml',
 ]);
 
 /**

--- a/src/security/sanitize-core.ts
+++ b/src/security/sanitize-core.ts
@@ -254,6 +254,10 @@ export const sanitizeHtmlCore = (html: string, options: SanitizeOptions = {}): s
   const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_ELEMENT);
 
   const toRemove: Element[] = [];
+  // Track ids already emitted so duplicate ids within the fragment are dropped:
+  // two elements sharing an id turn `document.getElementById`/named access into
+  // a clobberable HTMLCollection (the classic `<a id=x><a id=x name=y>` vector).
+  const seenIds = new Set<string>();
 
   while (walker.nextNode()) {
     const el = walker.currentNode as Element;
@@ -286,6 +290,17 @@ export const sanitizeHtmlCore = (html: string, options: SanitizeOptions = {}): s
       if ((attrName === 'id' || attrName === 'name') && !isSafeIdOrName(attr.value)) {
         attrsToRemove.push(attr.name);
         continue;
+      }
+
+      // Drop duplicate ids (HTMLCollection clobbering). The first occurrence is
+      // kept; later ones are stripped so named access resolves to a single node.
+      if (attrName === 'id') {
+        const idValue = attr.value.trim();
+        if (seenIds.has(idValue)) {
+          attrsToRemove.push(attr.name);
+          continue;
+        }
+        seenIds.add(idValue);
       }
 
       // Validate URL attributes

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -238,6 +238,20 @@ describe('security/enhanced protections', () => {
     expect(result).not.toContain('<script>');
   });
 
+  it('strips duplicate ids to prevent HTMLCollection clobbering (#179)', () => {
+    const result = String(sanitizeHtml('<a id="x"></a><a id="x" name="y">link</a>'));
+    // Only the first id="x" survives; the duplicate is stripped.
+    expect(result.match(/id="x"/g)?.length ?? 0).toBe(1);
+    expect(result).toContain('link');
+  });
+
+  it('blocks the expanded reserved-id denylist (#179)', () => {
+    for (const id of ['attributes', 'getElementById', 'defaultView', 'implementation']) {
+      const result = String(sanitizeHtml(`<div id="${id}">x</div>`));
+      expect(result).not.toContain(`id="${id}"`);
+    }
+  });
+
   it('blocks iframe tags', () => {
     const result = sanitizeHtml('<iframe src="evil.com"></iframe>');
     expect(result).not.toContain('<iframe');


### PR DESCRIPTION
## Summary
Fixes #179 (Low; defense-in-depth).

DOM-clobbering protection only stripped `id`/`name` values whose exact value was in a ~30-entry reserved list, and the classic duplicate-id HTMLCollection vector (`<a id=x></a><a id=x name=y>`) passed unchanged. The list was also missing many high-value targets (`attributes`, `nodeName`, `getElementById`, `defaultView`, `implementation`, …).

## Fix
- **Expanded `RESERVED_IDS`** with the missing global/document/node/traversal targets.
- **Duplicate-id stripping** in `sanitize-core.ts`: the first occurrence of an id is kept; later elements sharing it have their `id` dropped, so named access resolves to a single node.
- Documented that the `id`/`name` denylist is defense-in-depth, not a complete guarantee — fully untrusted content should drop `id`/`name` entirely.

## Verification
- New tests: duplicate `id="x"` reduced to one occurrence; several newly-added reserved ids (`attributes`, `getElementById`, `defaultView`, `implementation`) are stripped. Both fail on the pre-fix code.
- security/core/view suites: all pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
