### PR TITLE
fix(view): invoke bq-on handlers via evaluation, not a paren heuristic

### DIFF
--- a/src/view/directives/on-modifiers.ts
+++ b/src/view/directives/on-modifiers.ts
@@ -1,4 +1,4 @@
-import { evaluateRaw } from '../evaluate';
+import { runOnExpression } from './on-shared';
 import type { BindingContext } from '../types';
 
 const KEY_ALIASES: Record<string, string[]> = {
@@ -155,16 +155,7 @@ export const handleOnWithModifiers = (
         removeListener();
       }
 
-      const eventContext = { ...context, $event: event, $el: el };
-      const containsCall = expression.includes('(');
-      if (!containsCall) {
-        const result = evaluateRaw<unknown>(expression, eventContext);
-        if (typeof result === 'function') {
-          (result as (e: Event) => void)(event);
-        }
-        return;
-      }
-      evaluateRaw(expression, eventContext);
+      runOnExpression(expression, { ...context, $event: event, $el: el }, event);
     };
 
     el.addEventListener(eventName, handler, listenerOptions);

--- a/src/view/directives/on-shared.ts
+++ b/src/view/directives/on-shared.ts
@@ -1,0 +1,29 @@
+import { evaluateRaw } from '../evaluate';
+import type { BindingContext } from '../types';
+
+/**
+ * Evaluates a `bq-on` handler expression and, if it resolves to a function,
+ * invokes it with the event.
+ *
+ * Rather than guessing "bare reference vs. call" by string-scanning for `(`
+ * (which misfires on expressions like `items.find(x => x).handler` — a paren
+ * that is not the top-level call, causing the returned handler to never run),
+ * the expression is always evaluated. A function result is invoked with the
+ * event (so a bare `handler` or a resolved-to-function member chain fires);
+ * any other result means the expression itself was the side effect (e.g.
+ * `count.value++` or `handleClick($event)`).
+ *
+ * Note: `this` is unbound for a function resolved from a member chain — use an
+ * explicit call (`obj.method($event)`) when the receiver matters.
+ * @internal
+ */
+export const runOnExpression = (
+  expression: string,
+  eventContext: BindingContext,
+  event: Event
+): void => {
+  const result = evaluateRaw<unknown>(expression, eventContext);
+  if (typeof result === 'function') {
+    (result as (e: Event) => void)(event);
+  }
+};

--- a/src/view/directives/on.ts
+++ b/src/view/directives/on.ts
@@ -1,4 +1,4 @@
-import { evaluateRaw } from '../evaluate';
+import { runOnExpression } from './on-shared';
 import type { DirectiveHandler } from '../types';
 
 /**
@@ -8,31 +8,7 @@ import type { DirectiveHandler } from '../types';
 export const handleOn = (eventName: string): DirectiveHandler => {
   return (el, expression, context, cleanups) => {
     const handler = (event: Event) => {
-      // Add $event to context for expression evaluation
-      const eventContext = { ...context, $event: event, $el: el };
-
-      // Check if expression contains a function call (has parentheses)
-      // If not, it might be a plain function reference like "handleClick"
-      // Note: Method references like "handlers.onClick" will lose their receiver
-      // when auto-invoked. For methods, use explicit calls: "handlers.onClick($event)"
-      const containsCall = expression.includes('(');
-
-      if (!containsCall) {
-        // Evaluate the expression - if it returns a function, invoke it with $event
-        const result = evaluateRaw<unknown>(expression, eventContext);
-        if (typeof result === 'function') {
-          // Auto-invoke with event. Note: `this` will be undefined for method references.
-          // For proper method binding, use explicit syntax: "obj.method($event)"
-          result(event);
-          return;
-        }
-        // If not a function, the expression was already evaluated (e.g., "count.value++")
-        return;
-      }
-
-      // Otherwise evaluate as expression using evaluateRaw to allow signal mutations
-      // (e.g., "count.value++" or "handleClick($event)")
-      evaluateRaw(expression, eventContext);
+      runOnExpression(expression, { ...context, $event: event, $el: el }, event);
     };
 
     el.addEventListener(eventName, handler);

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -715,6 +715,29 @@ describe('View', () => {
       expect(count.value).toBe(6);
       expect(span.textContent).toBe('6');
     });
+
+    it('invokes a handler resolved from an expression containing inner parens (#180)', () => {
+      container.innerHTML = '<button bq-on:click="items.find(matcher).handler">Go</button>';
+      let called = false;
+      const items = [{ id: 1, handler: () => { called = true; } }];
+
+      view = mount(container, {
+        items,
+        matcher: (x: { id: number }) => x.id === 1,
+      });
+
+      container.querySelector('button')!.click();
+      expect(called).toBe(true);
+    });
+
+    it('invokes a bare handler reference with the event (#180)', () => {
+      container.innerHTML = '<button bq-on:click="onClick">Go</button>';
+      let receivedType = '';
+      view = mount(container, { onClick: (e: Event) => { receivedType = e.type; } });
+
+      container.querySelector('button')!.click();
+      expect(receivedType).toBe('click');
+    });
   });
 
   describe('bq-for', () => {


### PR DESCRIPTION
## Summary
Fixes #180 (Low; correctness — silent no-op).

`bq-on` decided "bare function reference vs. call" by testing whether the expression string contained `(`. This misfires on expressions where the paren is not the top-level call:

```html
<button bq-on:click="items.find(x => x).handler">
```

was treated as a full expression, evaluated once, and the returned `handler` was **never invoked** — the click silently did nothing.

## Fix
Both `bq-on` sinks (`on.ts` and `on-modifiers.ts`) now share `runOnExpression`: always evaluate the expression via `evaluateRaw`, and if the result is a function, invoke it with the event; otherwise the evaluation itself was the side effect (`count.value++`, `handleClick($event)`). The string heuristic is removed. (`this` remains unbound for a function resolved from a member chain — use an explicit call when the receiver matters, as before.)

## Verification
- New tests: a handler resolved from `items.find(matcher).handler` now fires; a bare `onClick` reference is invoked with the event. The inner-paren case is exactly what silently no-op'd on the pre-fix code.
- Existing bq-on tests (bare ref, `handleClick($event)`, `count.value++`/`--`/`+=`) still pass.
- view suites: 119 pass / 0 fail. `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
