### PR TITLE
fix(server): default file-route loader middleware to action middleware

### DIFF
--- a/src/server/file-routes.ts
+++ b/src/server/file-routes.ts
@@ -33,7 +33,14 @@ export interface FileRouteServerOptions {
   basePath?: string;
   /** Middleware applied to generated action routes (e.g. `csrf()`). */
   middlewares?: ServerMiddleware[];
-  /** Middleware applied to generated loader routes. */
+  /**
+   * Middleware applied to generated loader (JSON) routes. Defaults to
+   * {@link middlewares} when unset — a loader mirrors the same data an
+   * authenticated page renders, so protecting only actions with
+   * `middlewares: [auth]` would otherwise leave every route's `load()` output
+   * exposed as unauthenticated JSON. Pass `dataMiddlewares: []` to explicitly
+   * opt the loader routes out of the action middleware chain.
+   */
   dataMiddlewares?: ServerMiddleware[];
 }
 
@@ -111,6 +118,10 @@ export const createFileRouteServerRoutes = (
 ): ServerRoute[] => {
   const routes: ServerRoute[] = [];
   const actionMethod = options.actionMethod ?? 'POST';
+  // Default loader middleware to the action chain so `load()` output is not
+  // accidentally exposed as unauthenticated JSON (opt out with an explicit
+  // empty array).
+  const dataMiddlewares = options.dataMiddlewares ?? options.middlewares;
 
   for (const route of entries) {
     if (route.hasAction !== false) {
@@ -126,7 +137,7 @@ export const createFileRouteServerRoutes = (
       routes.push({
         path: joinPath(options.dataPath, joinPath(options.basePath, route.pattern)),
         method: 'GET',
-        middlewares: options.dataMiddlewares,
+        middlewares: dataMiddlewares,
         handler: loaderHandler(route),
       });
     }

--- a/tests/server-file-routes.test.ts
+++ b/tests/server-file-routes.test.ts
@@ -72,4 +72,42 @@ describe('createFileRouteServerRoutes', () => {
     const routes = createFileRouteServerRoutes(entries, { basePath: '/app' });
     expect(routes[0].path).toBe('/app/users/:id');
   });
+
+  it('defaults loader middleware to the action middleware chain (#181)', () => {
+    const auth: import('../src/server/index').ServerMiddleware = (_ctx, next) => next();
+    const { entries } = createFileRoutes({
+      'routes/users/[id]/+page.ts': {
+        default: 'User',
+        action: (() => ({})) as Action,
+        load: (() => ({})) as Load,
+      },
+    });
+
+    const routes = createFileRouteServerRoutes(entries, {
+      dataPath: '/__data',
+      middlewares: [auth],
+    });
+    const loaderRoute = routes.find((r) => r.method === 'GET');
+    // The loader inherits the action middleware chain when dataMiddlewares is unset.
+    expect(loaderRoute?.middlewares).toEqual([auth]);
+  });
+
+  it('allows opting the loader out with an explicit empty dataMiddlewares (#181)', () => {
+    const auth: import('../src/server/index').ServerMiddleware = (_ctx, next) => next();
+    const { entries } = createFileRoutes({
+      'routes/users/[id]/+page.ts': {
+        default: 'User',
+        action: (() => ({})) as Action,
+        load: (() => ({})) as Load,
+      },
+    });
+
+    const routes = createFileRouteServerRoutes(entries, {
+      dataPath: '/__data',
+      middlewares: [auth],
+      dataMiddlewares: [],
+    });
+    const loaderRoute = routes.find((r) => r.method === 'GET');
+    expect(loaderRoute?.middlewares).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #181 (Low; authz footgun by omission).

Action/HTML routes received `options.middlewares`; the JSON loader endpoints received a **separate** `options.dataMiddlewares`. A developer who protects mutations with `middlewares: [auth]` but forgets `dataMiddlewares` exposed every route's `load()` output as **unauthenticated JSON** at `${dataPath}<route>` — the loader mirrors the same data an authenticated page renders, so this is a plausible authorization bypass introduced by omission.

## Fix
`dataMiddlewares` now defaults to `middlewares` when unset (`options.dataMiddlewares ?? options.middlewares`). Pass `dataMiddlewares: []` to explicitly opt loader routes out of the action chain. Documented on the option.

## Verification
- New tests: with `middlewares: [auth]` and no `dataMiddlewares`, the generated GET loader route inherits `[auth]`; with an explicit `dataMiddlewares: []` it opts out. The default-inheritance test fails on the pre-fix code.
- server suites: all pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
